### PR TITLE
🐛 bug: fix test data config read bug

### DIFF
--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -69,11 +69,10 @@ def start():
         delay_rate = None
 
     # handle test user data config file
-    test_data_config = read_yaml(args.test_data_config)
-    test_data_config = validate_config_file_data(test_data_config)
-
-    if not test_data_config:
-        test_data_config = None
+    test_data_config = args.test_data_config
+    if test_data_config:
+        test_data_config = read_yaml(args.test_data_config)
+        test_data_config = validate_config_file_data(test_data_config)
 
     # parse args and run tests
     api_parser = OpenAPIParser(args.fpath)


### PR DESCRIPTION
Bug:

```bash
WARNING  Error Occurred While reading file: {'error': 'ValueError, path cannot be of None type'}
```