### PR TITLE
🐛 bug fix: fix file descriptor leak

### DIFF
--- a/src/offat/http.py
+++ b/src/offat/http.py
@@ -50,9 +50,9 @@ class AsyncRequests:
             dict: returns request and response data as dict
         '''
         is_new_session = False
-        connector = TCPConnector(ssl=self._ssl, limit=self._rate_limit,)
 
         if not session:
+            connector = TCPConnector(ssl=self._ssl, limit=self._rate_limit,)
             session = ClientSession(headers=self._headers, connector=connector)
             is_new_session = True
 


### PR DESCRIPTION
This PR addresses a file descriptor leak issue in the AsyncRequests class. The problem arises from not explicitly closing the TCPConnector after creating it for each request. Over time, this leads to a buildup of open file descriptors, potentially causing issues with the file descriptor limit.