### PR TITLE
FEATURE: do not store errored requests into output file

### DIFF
--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -119,6 +119,13 @@ def start():
         action='store_true',
         help='Enable SSL Verification',
     )
+    parser.add_argument(
+        '-cf',
+        '--capture-failed',
+        dest='capture_failed',
+        action='store_true',
+        help='Captures failed requests due to any exceptions into output file',
+    )
     args = parser.parse_args()
 
     # convert req headers str to dict
@@ -146,6 +153,7 @@ def start():
         test_data_config=test_data_config,
         proxies=args.proxies_list,
         ssl=args.ssl,
+        capture_failed=args.capture_failed,
     )
 
 

--- a/src/offat/report/generator.py
+++ b/src/offat/report/generator.py
@@ -120,11 +120,20 @@ class ReportGenerator:
 
     @staticmethod
     def generate_report(
-        results: list[dict], report_format: str | None, report_path: str | None
+        results: list[dict],
+        report_format: str | None,
+        report_path: str | None,
+        capture_failed: bool = False,
     ):
         """main function used to generate report"""
         if report_path:
             report_format = report_path.split('.')[-1]
+
+        # do not store errored results if `capture_failed` is False
+        if not capture_failed:
+            results = list(
+                filter(lambda result: result.get('error', True) == False, results)
+            )
 
         formatted_results = ReportGenerator.handle_report_format(
             results=results, report_format=report_format

--- a/src/offat/tester/tester_utils.py
+++ b/src/offat/tester/tester_utils.py
@@ -119,6 +119,7 @@ def generate_and_run_tests(
     proxies: list[str] | None = None,
     test_data_config: dict | None = None,
     ssl: bool = False,
+    capture_failed: bool = False,
 ):
     '''
     Generates and runs tests for provied OAS/Swagger file.


### PR DESCRIPTION
Feature Request Thread: https://github.com/OWASP/OFFAT/issues/72

output file will only store requests that received response from the server, other requests will be discarded by default while storing output.

Failed requests can be stored by using flag `-cf` or `--capture-failed`

Usage:

```bash
offat -f OAS.yml --capture-failed
```
