### PR TITLE
SSL Verify was not properly handled

### DIFF
--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -115,10 +115,10 @@ def start():
     )
     parser.add_argument(
         '-s',
-        '--ssl',
-        dest='ssl',
+        '--ssl_verify',
+        dest='ssl_verify',
         required=False,
-        action='store_true',
+        action='store_false',
         help='Enable SSL Verification',
     )
     parser.add_argument(
@@ -153,7 +153,8 @@ def start():
 
     # parse args and run tests
     api_parser: SwaggerParser | OpenAPIv3Parser = create_parser(
-        args.fpath, server_url=args.server_url
+        args.fpath, server_url=args.server_url,
+        ssl_verify=args.ssl_verify
     )
 
     generate_and_run_tests(
@@ -165,7 +166,6 @@ def start():
         rate_limit=rate_limit,
         test_data_config=test_data_config,
         proxies=args.proxies_list,
-        ssl=args.ssl,
         capture_failed=args.capture_failed,
     )
 

--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -115,7 +115,7 @@ def start():
     )
     parser.add_argument(
         '-s',
-        '--ssl_verify',
+        '--ssl-verify',
         dest='ssl_verify',
         required=False,
         action='store_true',

--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -118,7 +118,7 @@ def start():
         '--ssl_verify',
         dest='ssl_verify',
         required=False,
-        action='store_false',
+        action='store_true',
         help='Enable SSL Verification',
     )
     parser.add_argument(

--- a/src/offat/api/jobs.py
+++ b/src/offat/api/jobs.py
@@ -5,9 +5,9 @@ from offat.parsers import create_parser
 from offat.logger import logger
 
 
-def scan_api(body_data: CreateScanModel):
+def scan_api(body_data: CreateScanModel, ssl_verify: bool=True):
     try:
-        api_parser = create_parser(fpath_or_url=None, spec=body_data.openAPI)
+        api_parser = create_parser(fpath_or_url=None, spec=body_data.openAPI, ssl_verify=ssl_verify)
 
         results = generate_and_run_tests(
             api_parser=api_parser,

--- a/src/offat/http.py
+++ b/src/offat/http.py
@@ -64,7 +64,7 @@ class AsyncRequests:
         proxies: list[str] | None = [],
         allow_redirects: bool = True,
         timeout: float = 60,
-        ssl: bool = False,
+        ssl_verify: bool = True,
     ) -> None:
         """AsyncRequests class constructor
 
@@ -74,7 +74,7 @@ class AsyncRequests:
             headers (dict): overrides default headers while sending HTTP requests
             proxy (str): proxy URL to be used while sending requests
             timeout (float): total timeout parameter of aiohttp.ClientTimeout
-            ssl (bool): enforces tls/ssl verification if True
+            ssl_verify (bool): enforces tls/ssl verification if True
 
         Returns:
             None
@@ -84,7 +84,7 @@ class AsyncRequests:
         self._allow_redirects = allow_redirects
         self._limiter = AsyncLimiter(max_rate=rate_limit, time_period=1)
         self._timeout = ClientTimeout(total=timeout)
-        self._ssl = ssl
+        self._ssl_verify = ssl_verify
 
     @retry(
         stop=stop_after_attempt(3),
@@ -130,7 +130,7 @@ class AsyncRequests:
                     url,
                     allow_redirects=self._allow_redirects,
                     proxy=self._proxy.get_random_proxy(),
-                    ssl=self._ssl,
+                    ssl=self._ssl_verify,
                     *args,
                     **kwargs,
                 ) as response:

--- a/src/offat/parsers/__init__.py
+++ b/src/offat/parsers/__init__.py
@@ -11,10 +11,11 @@ def create_parser(
     fpath_or_url: str,
     spec: dict | None = None,
     server_url: str | None = None,
+    ssl_verify: bool = True
 ) -> SwaggerParser | OpenAPIv3Parser:
     """returns parser based on doc file"""
     if fpath_or_url and is_valid_url(fpath_or_url):
-        res = http_get(fpath_or_url, timeout=3)
+        res = http_get(fpath_or_url, timeout=3, verify=ssl_verify)
         if res.status_code != 200:
             logger.error(
                 'server returned status code %d offat expects 200 status code',

--- a/src/offat/tester/handler.py
+++ b/src/offat/tester/handler.py
@@ -25,7 +25,6 @@ def generate_and_run_tests(
     req_headers: dict | None = None,
     proxies: list[str] | None = None,
     test_data_config: dict | None = None,
-    ssl: bool = False,
     capture_failed: bool = False,
     remove_unused_data: bool = True,
 ):
@@ -49,8 +48,6 @@ def generate_and_run_tests(
         (optional).
         test_data_config: A dictionary representing the configuration
         for user-provided test data (optional).
-        ssl: A boolean indicating whether to use SSL for the requests
-        (default: False).
         capture_failed: A boolean indicating whether to capture failed
         tests in the report (default: False).
         remove_unused_data: A boolean indicating whether to remove
@@ -71,7 +68,6 @@ def generate_and_run_tests(
         rate_limit=rate_limit,
         headers=req_headers,
         proxies=proxies,
-        ssl=ssl,
     )
 
     results: list = []

--- a/src/offat/tester/handler.py
+++ b/src/offat/tester/handler.py
@@ -61,7 +61,7 @@ def generate_and_run_tests(
     """
     if not is_host_up(openapi_parser=api_parser):
         logger.error(
-            'Stopping tests due to unavailibility of host: %s', api_parser.host
+            'Stopping tests due to unavailability of host: %s', api_parser.host
         )
         return
 

--- a/src/offat/tester/runner.py
+++ b/src/offat/tester/runner.py
@@ -24,10 +24,13 @@ class TestRunner:
         rate_limit: float = 60,
         headers: dict | None = None,
         proxies: list[str] | None = None,
-        ssl: bool = False,
+        ssl_verify: bool = True,
     ) -> None:
         self._client = AsyncRequests(
-            rate_limit=rate_limit, headers=headers, proxies=proxies, ssl=ssl
+            rate_limit=rate_limit,
+            headers=headers,
+            proxies=proxies,
+            ssl_verify=ssl_verify
         )
         self.progress = Progress(console=console)
         self.progress_task_id: TaskID | None = None


### PR DESCRIPTION
A few fixes in this PR:
1. `ssl_verify` is used rather the `ssl` variable
2. Add ssl_verify handling where there wasn't one
3. Remove `ssl` directive where its not relevant (it was used to 'enable' ssl, but wasn't actually used in the underlying code)