### PR TITLE
Fix `ssl_verify` and `https` detection 

### DIFF
--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -167,6 +167,7 @@ def start():
         test_data_config=test_data_config,
         proxies=args.proxies_list,
         capture_failed=args.capture_failed,
+        ssl_verify=args.ssl_verify,
     )
 
 

--- a/src/offat/api/jobs.py
+++ b/src/offat/api/jobs.py
@@ -22,6 +22,7 @@ def scan_api(body_data: CreateScanSchema, ssl_verify: bool = True):
             proxies=body_data.proxies,
             capture_failed=body_data.capture_failed,
             remove_unused_data=body_data.remove_unused_data,
+            ssl_verify=ssl_verify,
         )
         return results
     except Exception as e:

--- a/src/offat/tester/handler.py
+++ b/src/offat/tester/handler.py
@@ -27,6 +27,7 @@ def generate_and_run_tests(
     test_data_config: dict | None = None,
     capture_failed: bool = False,
     remove_unused_data: bool = True,
+    ssl_verify: bool = True,
 ):
     """
     Generates and runs tests for the provided OAS/Swagger file.
@@ -56,7 +57,7 @@ def generate_and_run_tests(
     Returns:
         A list of test results.
     """
-    if not is_host_up(openapi_parser=api_parser):
+    if not is_host_up(openapi_parser=api_parser, ssl_verify=ssl_verify):
         logger.error(
             'Stopping tests due to unavailability of host: %s', api_parser.host
         )

--- a/src/offat/tester/tester_utils.py
+++ b/src/offat/tester/tester_utils.py
@@ -32,6 +32,9 @@ def is_host_up(openapi_parser: SwaggerParser | OpenAPIv3Parser, ssl_verify: bool
             logger.warning('Invalid host: %s', openapi_parser.host)
             return False
 
+    if openapi_parser.http_scheme == 'https':
+        use_ssl = True
+
     host = host.split('/')[0]
 
     match port:
@@ -39,7 +42,10 @@ def is_host_up(openapi_parser: SwaggerParser | OpenAPIv3Parser, ssl_verify: bool
             use_ssl = True
             proto = http_client.HTTPSConnection
         case _:
-            proto = http_client.HTTPConnection
+            if use_ssl:
+                proto = http_client.HTTPSConnection
+            else:
+                proto = http_client.HTTPConnection
 
     logger.info('Checking whether host %s:%s is available', host, port)
     try:

--- a/src/offat/tests/self_signed/self_signed_server_tester.py
+++ b/src/offat/tests/self_signed/self_signed_server_tester.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+# Generate a cert:
+# openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365
+
+import http.server
+import ssl
+
+
+class SimpleHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    pass
+
+
+httpd = http.server.HTTPServer(("localhost", 4443), SimpleHTTPRequestHandler)
+httpd.socket = ssl.wrap_socket(
+    httpd.socket, keyfile="key.pem", certfile="cert.pem", server_side=True
+)
+
+print("Serving on https://localhost:4443")
+httpd.serve_forever()


### PR DESCRIPTION
This PR fixes - https://github.com/OWASP/OFFAT/issues/114

The issues raised by this issue:
1. ssl_verify wasn't passed everywhere (a mistake)
2. `https` isn't used to enable `use_ssl`, which is bad design

So this fixes:
1. ssl_verify wasn't passed to all places
2. 'detect' https and enable `use_ssl`
