### PR TITLE
new flag --only-get-requests

### DIFF
--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -48,6 +48,14 @@ def start():
         '-v', '--version', action='version', version=f"%(prog)s {get_package_version()}"
     )
     parser.add_argument(
+        '--only-get-requests',
+        dest='only_get_requests',
+        help="send only get requests while scanning",
+        action='store_true',
+        default=False,
+        required=False
+    )
+    parser.add_argument(
         '-rl',
         '--rate-limit',
         dest='rate_limit',
@@ -168,6 +176,7 @@ def start():
         proxies=args.proxies_list,
         capture_failed=args.capture_failed,
         ssl_verify=args.ssl_verify,
+        only_get_requests=args.only_get_requests,
     )
 
 

--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -50,7 +50,7 @@ def start():
     parser.add_argument(
         '--only-get-requests',
         dest='only_get_requests',
-        help="send only get requests while scanning",
+        help="send only GET requests while scanning",
         action='store_true',
         default=False,
         required=False

--- a/src/offat/__main__.py
+++ b/src/offat/__main__.py
@@ -48,11 +48,12 @@ def start():
         '-v', '--version', action='version', version=f"%(prog)s {get_package_version()}"
     )
     parser.add_argument(
-        '--only-get-requests',
-        dest='only_get_requests',
-        help="send only GET requests while scanning",
-        action='store_true',
-        default=False,
+        '--http-methods',
+        dest='http_methods',
+        nargs='+',
+        choices=['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH'],
+        help="Specify one or more HTTP methods to use while scanning. Allowed values: GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH",
+        default=['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH'],
         required=False
     )
     parser.add_argument(
@@ -167,6 +168,7 @@ def start():
 
     generate_and_run_tests(
         api_parser=api_parser,
+        http_methods=args.http_methods,
         regex_pattern=args.path_regex_pattern,
         output_file=args.output_file,
         output_file_format=args.output_format,
@@ -176,7 +178,6 @@ def start():
         proxies=args.proxies_list,
         capture_failed=args.capture_failed,
         ssl_verify=args.ssl_verify,
-        only_get_requests=args.only_get_requests,
     )
 
 

--- a/src/offat/tester/handler.py
+++ b/src/offat/tester/handler.py
@@ -28,6 +28,7 @@ def generate_and_run_tests(
     capture_failed: bool = False,
     remove_unused_data: bool = True,
     ssl_verify: bool = True,
+    only_get_requests: bool = False,
 ):
     """
     Generates and runs tests for the provided OAS/Swagger file.
@@ -70,6 +71,7 @@ def generate_and_run_tests(
         headers=req_headers,
         proxies=proxies,
         ssl_verify=ssl_verify,
+        only_get_requests=only_get_requests,
     )
 
     results: list = []

--- a/src/offat/tester/handler.py
+++ b/src/offat/tester/handler.py
@@ -18,6 +18,7 @@ test_generator = TestGenerator()
 # Note: redirects are allowed by default making it easier for pentesters/researchers
 def generate_and_run_tests(
     api_parser: SwaggerParser | OpenAPIv3Parser,
+    http_methods: list,
     regex_pattern: str | None = None,
     output_file: str | None = None,
     output_file_format: str | None = None,
@@ -28,7 +29,6 @@ def generate_and_run_tests(
     capture_failed: bool = False,
     remove_unused_data: bool = True,
     ssl_verify: bool = True,
-    only_get_requests: bool = False,
 ):
     """
     Generates and runs tests for the provided OAS/Swagger file.
@@ -67,11 +67,11 @@ def generate_and_run_tests(
     logger.info('Host %s is up', api_parser.host)
 
     test_runner = TestRunner(
+        http_methods=http_methods,
         rate_limit=rate_limit,
         headers=req_headers,
         proxies=proxies,
         ssl_verify=ssl_verify,
-        only_get_requests=only_get_requests,
     )
 
     results: list = []

--- a/src/offat/tester/runner.py
+++ b/src/offat/tester/runner.py
@@ -22,11 +22,11 @@ class TestRunner:
 
     def __init__(
         self,
+        http_methods: list,
         rate_limit: float = 60,
         headers: dict | None = None,
         proxies: list[str] | None = None,
         ssl_verify: bool = True,
-        only_get_requests: bool = False,
     ) -> None:
         self._client = AsyncRequests(
             rate_limit=rate_limit,
@@ -34,7 +34,7 @@ class TestRunner:
             proxies=proxies,
             ssl_verify=ssl_verify,
         )
-        self.only_get_requests = only_get_requests
+        self.http_methods = http_methods
         self.progress = Progress(console=console)
         self.progress_task_id: TaskID | None = None
 
@@ -127,7 +127,7 @@ class TestRunner:
             )
 
         test_result = test_task
-        if str(http_method).upper() != "GET" and self.only_get_requests:
+        if self.http_methods and str(http_method).upper() not in self.http_methods:
             test_result['request_headers'] = []
             test_result['response_headers'] = []
             test_result['response_body'] = f"{str(http_method).upper()} request was not sent"


### PR DESCRIPTION
This pull request introduces a new flag: `--only-get-requests`.

I'm currently working on the API scanning module for the [Artemis](https://github.com/CERT-Polska/Artemis) project, and we needed this functionality to avoid performing intrusive scans. The goal is to restrict the scanner to non-intrusive GET requests only. You can find the related implementation in [this pull request](https://github.com/CERT-Polska/Artemis/pull/1753).

It would be greatly appreciated if you could review and consider merging this.