### PR TITLE
Remove upper bound in dependency contraints

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -7,19 +7,19 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
-aiohttp = "^3.8.4"
-pyyaml = "^6.0"
-fastapi = {version = "^0.115.2", optional = true}
-uvicorn = {extras = ["standard"], version = "^0.23.2", optional = true}
-rq = {version = "^1.15.1", optional = true}
-redis = {version = "^5.0.0", optional = true}
-python-dotenv = {version = "^1.0.0", optional = true}
-rich = "^13.7.0"
-aiolimiter = "^1.1.0"
-openapi-spec-validator = "^0.7.1"
+python = ">=3.10"
+aiohttp = ">=3.8.4"
+pyyaml = ">=6.0"
+fastapi = {version = ">=0.115.2", optional = true}
+uvicorn = {extras = ["standard"], version = ">=0.23.2", optional = true}
+rq = {version = ">=1.15.1", optional = true}
+redis = {version = ">=5.0.0", optional = true}
+python-dotenv = {version = ">=1.0.0", optional = true}
+rich = ">=13.7.0"
+aiolimiter = ">=1.1.0"
+openapi-spec-validator = ">=0.7.1"
 setuptools = ">=69.0.3"
-tenacity = "^8.2.3"
+tenacity = ">=8.2.3"
 
 [tool.poetry.extras]
 api = ["fastapi", "uvicorn", "redis", "rq", "python-dotenv"]
@@ -36,7 +36,7 @@ offat-api = "offat.api.__main__:start"
 
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.1.1"
+pytest = ">=8.1.1"
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
Updated dependency version constraints to use '>=' instead of '^'.

## Alternative

Use [`poetry-relax`](https://pypi.org/project/poetry-relax/)

## References (taken from `poetry-relax`):

There's a lot to read on this topic! It's contentious and causing a lot of problems for maintainers and users.

The following blog posts by Henry Schreiner are quite comprehensive:

-   [Should You Use Upper Bound Version Constraints?](https://iscinumpy.dev/post/bound-version-constraints/)
-   [Poetry Versions](https://iscinumpy.dev/post/poetry-versions/)

Content from some members of the Python core developer team:

-   [Semantic Versioning Will Not Save You](https://hynek.me/articles/semver-will-not-save-you/)
-   [Why I don't like SemVer anymore](https://snarky.ca/why-i-dont-like-semver/)
-   [Version numbers: how to use them?](https://bernat.tech/posts/version-numbers/)
-   [Versioning Software](https://caremad.io/posts/2016/02/versioning-software/)

Discussion and issues in the Poetry project:

-   [Please stop pinning to major versions by default, especially for Python itself](https://github.com/python-poetry/poetry/issues/3747)
-   [Change default dependency constraint from ^ to >=](https://github.com/python-poetry/poetry/issues/3427)
-   [Developers should be able to turn off dependency upper-bound calculations](https://github.com/python-poetry/poetry/issues/2731)