### PR TITLE
Accept YAML OpenAPI/Swagger spec when fetched from a URL

### DIFF
--- a/src/offat/parsers/__init__.py
+++ b/src/offat/parsers/__init__.py
@@ -1,5 +1,5 @@
-from json import loads as json_load, JSONDecodeError
 from requests import get as http_get
+from yaml import safe_load as yaml_load, YAMLError
 from .openapi import OpenAPIv3Parser
 from .swagger import SwaggerParser
 from .parser import BaseParser
@@ -23,12 +23,19 @@ def create_parser(
             )
             exit(-1)
 
+        # A spec served over a url can be JSON or YAML, same as a local file.
+        # JSON is a subset of YAML, so safe_load handles both.
         try:
-            spec = json_load(res.text)
-            fpath_or_url = None  # type: ignore
-        except JSONDecodeError:
-            logger.error('Invalid json data spec file url')
+            spec = yaml_load(res.text)
+        except YAMLError:
+            logger.error('Failed to parse spec fetched from url as JSON/YAML')
             exit(-1)
+
+        if not isinstance(spec, dict):
+            logger.error('Spec fetched from url is not a valid JSON/YAML object')
+            exit(-1)
+
+        fpath_or_url = None  # type: ignore
 
     try:
         parser = BaseParser(file_or_url=fpath_or_url, spec=spec, server_url=server_url)

--- a/src/offat/tests/parsers/test_parser.py
+++ b/src/offat/tests/parsers/test_parser.py
@@ -1,7 +1,9 @@
 import tempfile
 
 import unittest
-from ...parsers import BaseParser
+from unittest.mock import patch, MagicMock
+from ...parsers import BaseParser, create_parser
+from ...parsers.openapi import OpenAPIv3Parser
 
 
 class TestBaseParser(unittest.TestCase):
@@ -55,3 +57,45 @@ class TestBaseParser(unittest.TestCase):
             '/api/render' in end_points,
             "Spec has '/api/render'"
         )
+
+
+class TestCreateParserFromUrl(unittest.TestCase):
+    _YAML_SPEC = """
+openapi: 3.0.0
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /api/render:
+    post:
+      operationId: operationId
+      responses:
+        "201":
+          description: Rendered result
+servers:
+  - url: https://someserver.com
+"""
+
+    _JSON_SPEC = (
+        '{"openapi": "3.0.0", "info": {"title": "Test", "version": "1.0"},'
+        ' "paths": {"/api/render": {"post": {"operationId": "operationId",'
+        ' "responses": {"201": {"description": "ok"}}}}},'
+        ' "servers": [{"url": "https://someserver.com"}]}'
+    )
+
+    def _create_from_url(self, body):
+        fake_res = MagicMock()
+        fake_res.status_code = 200
+        fake_res.text = body
+        with patch("offat.parsers.http_get", return_value=fake_res):
+            return create_parser("https://example.com/openapi.yaml")
+
+    def test_yaml_spec_from_url(self):
+        parser = self._create_from_url(self._YAML_SPEC)
+        self.assertIsInstance(parser, OpenAPIv3Parser)
+        self.assertEqual(parser.specification.get("openapi"), "3.0.0")
+
+    def test_json_spec_from_url(self):
+        parser = self._create_from_url(self._JSON_SPEC)
+        self.assertIsInstance(parser, OpenAPIv3Parser)
+        self.assertEqual(parser.specification.get("openapi"), "3.0.0")


### PR DESCRIPTION
Hi, thanks for OFFAT.

The -f flag takes a path or a URL, and a local YAML spec loads fine, but a YAML spec served over a URL gets rejected. In create_parser the fetched body is run through json.loads, so anything that isn't JSON exits with "Invalid json data spec file url". Plenty of OpenAPI specs are published as YAML (raw.githubusercontent, Swagger's own openapi.yaml), so offat -f https://.../openapi.yaml fails today even though the same file on disk works.

Switched the URL branch to yaml.safe_load. JSON is a subset of YAML so JSON URLs keep working, and YAML now loads the same way read_from_filename handles a local file. Added an isinstance check so a non-object 200 response still errors cleanly instead of failing later with an AttributeError. pyyaml is already a dependency.

Added tests for YAML and JSON specs fetched from a URL. Existing tests still pass.